### PR TITLE
update: Add `deleteUserFromGroups` function with sequential deletion

### DIFF
--- a/modules/controllers/userController.js
+++ b/modules/controllers/userController.js
@@ -6,10 +6,12 @@ import {
 } from "../../utils/error.js";
 import { search } from "../../utils/ldapUtils.js";
 import OrganizationService from "../services/orgainzationService.js";
+import GroupService from "../services/groupService.js";
 class UserController {
   constructor() {
     this.userService = new UserService();
     this.organizationService = new OrganizationService();
+    this.groupService = new GroupService();
   }
 
   // Add a new user to the LDAP directory
@@ -204,8 +206,14 @@ class UserController {
       // console.log("User exists", userExists[0]);
 
       const message = await this.userService.deleteUser(username, userOU);
+
+      // Deleting users from all users (if present)
+      const removeFromGroups = await this.groupService.deleteUserFromGroups(
+        username,
+        userOU
+      );
       console.log("Controller: deleteUser - Completed");
-      res.status(200).json(message);
+      res.status(200).json({ message, removeFromGroups });
     } catch (error) {
       console.log("Controller: deleteUser - Error", error);
       next(error);

--- a/modules/routes/groupRoutes.js
+++ b/modules/routes/groupRoutes.js
@@ -14,5 +14,6 @@ const groupRoutes = (app) => {
   router.get("/membersInGroup", groupController.membersInGroup); // List members in group - additional
   router.post("/addToAdminGroup", groupController.addToAdminGroup); // Add user to admin group
   router.delete("/deleteFromAdminGroup", groupController.deleteFromAdminGroup); // Delete user from admin group
+  router.delete("/deleteMemberFromGroups", groupController.deleteUserFromGroups); // Delete member from all groups
 };
 export default groupRoutes;

--- a/modules/services/groupService.js
+++ b/modules/services/groupService.js
@@ -6,11 +6,11 @@ import {
 } from "../../utils/error.js";
 
 class GroupService {
-  async createGroup(groupName, description, groupType, OU) {
+  async createGroup(groupName, description, groupType, groupOU) {
     try {
       console.log("Service: createGroup - Started");
       await bind(process.env.LDAP_ADMIN_DN, process.env.LDAP_ADMIN_PASSWORD);
-      const groupDN = `cn=${groupName},ou=${OU},${process.env.LDAP_BASE_DN}`;
+      const groupDN = `cn=${groupName},ou=${groupOU},${process.env.LDAP_BASE_DN}`;
       const groupAttributes = {
         cn: groupName,
         objectClass: ["top", "groupOfNames"],
@@ -109,12 +109,12 @@ class GroupService {
     }
   }
 
-  async deleteFromGroup(groupName, member, OU) {
+  async deleteFromGroup(groupName, groupOU, member, memberOU) {
     try {
       console.log("Service: deleteFromGroup - Started");
       await bind(process.env.LDAP_ADMIN_DN, process.env.LDAP_ADMIN_PASSWORD);
-      const groupDN = `cn=${groupName},ou=${OU},${process.env.LDAP_BASE_DN}`;
-      const userDN = `cn=${member},ou=users,${process.env.LDAP_BASE_DN}`;
+      const groupDN = `cn=${groupName},ou=${groupOU},${process.env.LDAP_BASE_DN}`;
+      const userDN = `cn=${member},ou=${memberOU},${process.env.LDAP_BASE_DN}`;
 
       // const groupDetails = await search(groupDN, "(objectClass=groupOfNames)");
       // const existingMember = groupDetails[0]?.member;
@@ -132,7 +132,11 @@ class GroupService {
       ];
       await modify(groupDN, changes);
       console.log("Service: deleteFromGroup - Completed");
-      return { message: "User deleted from group successfully." };
+      return {
+        message: "User deleted from group successfully.",
+        groupName: groupName,
+        groupOU: groupOU,
+      };
     } catch (error) {
       console.log("Service: deleteFromGroup - Error", error);
       if (error.message.includes("No Such Object")) {
@@ -221,18 +225,18 @@ class GroupService {
     }
   }
 
-  async deleteFromAdminGroup(groupName, member, groupOUValue, memberOUValue) {
+  async deleteFromAdminGroup(groupName, groupOUValue, member, memberOUValue) {
     try {
-      console.log("Service: deleteFromGroup - Started");
+      console.log("Service: deleteFromGroup (Admin) - Started");
       await bind(process.env.LDAP_ADMIN_DN, process.env.LDAP_ADMIN_PASSWORD);
       const groupDN = `cn=${groupName},ou=${groupOUValue},${process.env.LDAP_BASE_DN}`;
       const userDN = `cn=${member},ou=${memberOUValue},${process.env.LDAP_BASE_DN}`;
 
-      const groupDetails = await search(groupDN, "(objectClass=groupOfNames)");
-      const existingMember = groupDetails[0]?.member;
-      if (!existingMember.includes(userDN)) {
-        throw new ConflictError(`User ${member} is not a member of the group.`);
-      }
+      // const groupDetails = await search(groupDN, "(objectClass=groupOfNames)");
+      // const existingMember = groupDetails[0]?.member;
+      // if (!existingMember.includes(userDN)) {
+      //   throw new ConflictError(`User ${member} is not a member of the group.`);
+      // }
 
       const changes = [
         {
@@ -243,11 +247,107 @@ class GroupService {
         },
       ];
       await modify(groupDN, changes);
-      console.log("Service: deleteFromGroup - Completed");
-      return { message: "User deleted from group successfully." };
+      console.log("Service: deleteFromGroup (Admin) - Completed");
+      return {
+        message: "User deleted from group successfully.",
+        groupName: groupName,
+        groupOU: groupOUValue,
+      };
     } catch (error) {
-      console.log("Service: deleteFromGroup - Error", error);
-      throw error;
+      console.log("Service: deleteFromGroup (Admin) - Error", error);
+      //Error to inform member is not in group
+      if (error.message.includes("modify/delete: member: no such value")) {
+        throw new BadRequestError(
+          `User '${member}' is not a member of the group.`
+        );
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async findGroupsByMember(userDN) {
+    try {
+      console.log("Service: findGroupsByMember - Started");
+      const baseDN = `${process.env.LDAP_BASE_DN}`;
+      const groups = await search(
+        baseDN,
+        `(&(objectClass=groupOfNames)(member=${userDN}))`
+      );
+
+      console.log("Service: findGroupsByMember - Completed");
+      return groups; // Returns an array of groups where the user is a member
+    } catch (error) {
+      console.log("Service: findGroupsByMember - Error", error);
+      throw new Error("Error fetching groups for the member.");
+    }
+  }
+
+  async deleteUserFromGroups(member, memberOU) {
+    try {
+      console.log("Service: deleteUserFromGroups - Started");
+      const userDN = `cn=${member},ou=${memberOU},${process.env.LDAP_BASE_DN}`; // Construct the user's distinguished name (DN)
+
+      const groups = await this.findGroupsByMember(userDN); // Fetch all groups containing the member
+
+      let groupCount = 0;
+
+      if (groups.length === 0) {
+        return {
+          message: `User ${member} is not a member of any group.`,
+          groupCount,
+        };
+      }
+
+      const deleteResults = [];
+
+      // Iterating through each group to delete the user based on category
+      for (const group of groups) {
+        groupCount++; // Increment the group count
+        const groupName = group.cn; // Assuming `group` has a `cn` property for the group name
+        const groupOU = group.dn.match(/ou=([^,]+)/)[1]; // Extract only the value after "ou="
+        const businessCategory = group.businessCategory; // Fetch the business category from the group
+
+        console.warn(
+          `S.No:${groupCount}, Groupname:${groupName}, GroupOU:${groupOU}, BusinessCategory:${businessCategory}`
+        );
+
+        let result;
+
+        // Check the business category and call the appropriate service method
+        if (businessCategory === "admin") {
+          result = await this.deleteFromAdminGroup(
+            groupName,
+            groupOU,
+            member,
+            memberOU
+          );
+        } else if (businessCategory === "general") {
+          result = await this.deleteFromGroup(
+            groupName,
+            groupOU,
+            member,
+            memberOU
+          );
+        } else {
+          // If businessCategory doesn't match, log and skip
+          console.error(`Unknown business category: ${businessCategory}`);
+          continue;
+        }
+
+        deleteResults.push(result); // Push the result to the deleteResults array
+        console.warn(`Result: ${JSON.stringify(result)}`);
+      }
+
+      console.log("Service: deleteUserFromGroups - Completed");
+      return {
+        message: `User ${member} removed from groups successfully.`,
+        groupCount: groupCount,
+        results: deleteResults,
+      };
+    } catch (error) {
+      console.log("Service: deleteUserFromGroups - Error", error);
+      throw new Error("Error fetching groups for the member.");
     }
   }
 }


### PR DESCRIPTION
Add sequential user deletion from LDAP groups by category

Implement `deleteUserFromGroups` to remove a user from all LDAP groups 
by iterating through business categories (`admin`, `general`). Ensures:
- Group data is fetched by user's DN for targeted deletion
- Deletion functions are `awaited` to avoid incomplete results
- Stores feedback on each deletion in `deleteResults` array for clear 
  response on processed groups
